### PR TITLE
Disable rotating model

### DIFF
--- a/src/vulkan_app/app.rs
+++ b/src/vulkan_app/app.rs
@@ -1,6 +1,5 @@
 use ash::{vk, Entry};
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
-use std::time::Instant;
 
 use super::utils::{QueueFamilyIndices, UniformBufferObject};
 use super::vertex::{Vertex, INDICES, VERTICES, generate_wireframe_vertices};
@@ -47,7 +46,6 @@ pub struct VulkanApp {
     pub(super) descriptor_set_layout: vk::DescriptorSetLayout,
     pub(super) descriptor_pool: vk::DescriptorPool,
     pub(super) descriptor_sets: Vec<vk::DescriptorSet>,
-    pub(super) start_time: Instant,
     pub(super) depth_image: vk::Image,
     pub(super) depth_image_memory: vk::DeviceMemory,
     pub(super) depth_image_view: vk::ImageView,
@@ -207,7 +205,6 @@ impl VulkanApp {
             descriptor_set_layout,
             descriptor_pool,
             descriptor_sets,
-            start_time: Instant::now(),
             depth_image,
             depth_image_memory,
             depth_image_view,

--- a/src/vulkan_app/buffers.rs
+++ b/src/vulkan_app/buffers.rs
@@ -1,5 +1,5 @@
-use ash::{vk};
-use cgmath::{Matrix4, Point3, Vector3};
+use ash::vk;
+use cgmath::Matrix4;
 
 use super::{utils::{QueueFamilyIndices, UniformBufferObject}, vertex::{Vertex, INDICES}, VulkanApp};
 
@@ -140,9 +140,7 @@ pub fn create_uniform_buffers(
 
 impl VulkanApp {
     pub fn update_uniform_buffer(&self, current_image: usize, camera: &crate::camera::Camera) {
-        let time = self.start_time.elapsed().as_secs_f32();
-
-        let model = Matrix4::from_angle_z(cgmath::Deg(time * 90.0));
+        let model = Matrix4::identity();
         let view = camera.view_matrix();
         let mut proj = cgmath::perspective(
             cgmath::Deg(45.0),


### PR DESCRIPTION
## Summary
- remove time-based rotation in uniform update
- drop unused `start_time` tracking

## Testing
- `cargo check` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688690ae819c83228d7a186606b48279